### PR TITLE
Fix comparing northpole-southpole

### DIFF
--- a/R/antipodal.R
+++ b/R/antipodal.R
@@ -5,17 +5,17 @@
 
 
 antipodal <- function(p1, p2, tol=1e-9) {
-	p1 <- .pointsToMatrix(p1) 
-	p2 <- .pointsToMatrix(p2) 
-	p <- cbind(p1[,1], p1[,2], p2[,1], p2[,2])	
+	p1 <- .pointsToMatrix(p1)
+	p2 <- .pointsToMatrix(p2)
+	p <- cbind(p1[,1], p1[,2], p2[,1], p2[,2])
 	p[,c(1,3)] <- .normalizeLonDeg(p[,c(1,3)])
-	diflon <- abs(p[,1] - p[,3]) 
+	diflon <- abs(p[,1] - p[,3])
 	diflat <- abs(p[,2] + p[,4])
 	## FIX by Gareth Davies
 #	(diflat < tol) & (diflon > (180 - tol))
 	## FIX by Jonathan Rynd
-#       (diflat < tol) & (abs(diflon%%360 - 180) < tol) 	
-        (diflat < tol) & (abs(cos(p[,2]))*abs(diflon%%360 - 180) < tol) 	
+#	(diflat < tol) & (abs(diflon%%360 - 180) < tol)
+	(diflat < tol) & (cos(p[,2]*3.14159/180)*abs(diflon%%360 - 180) < tol) 	
 }
 
 

--- a/R/antipodal.R
+++ b/R/antipodal.R
@@ -13,7 +13,9 @@ antipodal <- function(p1, p2, tol=1e-9) {
 	diflat <- abs(p[,2] + p[,4])
 	## FIX by Gareth Davies
 #	(diflat < tol) & (diflon > (180 - tol))
-    (diflat < tol) & (abs(diflon%%360 - 180) < tol) 	
+	## FIX by Jonathan Rynd
+#       (diflat < tol) & (abs(diflon%%360 - 180) < tol) 	
+        (diflat < tol) & (abs(cos(p[,2]))*abs(diflon%%360 - 180) < tol) 	
 }
 
 


### PR DESCRIPTION
If northpole represented as latitude=90 longitude=0 and southpole represented as latitude=-90 longitude=0, existing function claims they're not antipodes. This fixes it.