### PR TITLE
Fixing out of domaine acos() in alongTrackDistance()

### DIFF
--- a/R/alongTrack.R
+++ b/R/alongTrack.R
@@ -17,18 +17,24 @@ alongTrackDistance <- function(p1, p2, p3, r=6378137) {
 	p2 <- p[,3:4,drop=FALSE]
 	p3 <- p[,5:6,drop=FALSE]
 	r = p[,7]
-	
+
 	tc <- bearing(p1, p2) * toRad
 	tcp <- bearing(p1, p3) * toRad
     dp <- distCosine(p1, p3, r=1)
 	xtr <- asin(sin(tcp-tc) * sin(dp))
 
 # +1/-1 for ahead/behind [lat1,lon1]
-	bearing <- sign(cos(tc - tcp))  
-	
-	dist <- bearing * acos(round(cos(dp) / cos(xtr), 15)) * r # Rounding one digit below machine eps
+	bearing <- sign(cos(tc - tcp))
+	angle <- cos(dp) / cos(xtr)
+
+# Fixing limits for the angle between [-1, 1] to avoid NaNs
+	angle[angle > 1] <- 1
+	angle[angle < -1] <- -1
+
+	dist <- bearing * acos(angle) * r
+
 	if (is.vector(dist)) { dist <- matrix(dist) }
 	colnames(dist) <- 'distance'
-	
+
 	return(abs(dist))
 }

--- a/R/alongTrack.R
+++ b/R/alongTrack.R
@@ -25,8 +25,8 @@ alongTrackDistance <- function(p1, p2, p3, r=6378137) {
 
 # +1/-1 for ahead/behind [lat1,lon1]
 	bearing <- sign(cos(tc - tcp))  
-	dist <- bearing * acos(cos(dp) / cos(xtr)) * r
 	
+	dist <- bearing * acos(round(cos(dp) / cos(xtr), 15)) * r # Rounding one digit below machine eps
 	if (is.vector(dist)) { dist <- matrix(dist) }
 	colnames(dist) <- 'distance'
 	


### PR DESCRIPTION
Hi ! 

In some rare case, like those reported by #3, https://github.com/rspatial/geosphere/blob/0a775039177646d093edc23c709267ffc7094d76/R/alongTrack.R#L28
The angle in the `acos(cos(dp) / cos(xtr))` function can be slightly lower than -1 or higher than +1 due to due to the rounding and machine precision. I added this quick (and maybe a bit dirty) fix to ensure that the angle stays within the domain of the arc-cosine function.
