### PR TITLE
Directly include system headers

### DIFF
--- a/src/AlbersEqualArea.cpp
+++ b/src/AlbersEqualArea.cpp
@@ -7,6 +7,10 @@
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
 
+#include <cmath>
+#include <limits> // std::numeric_limits
+#include <string> // std::to_string
+#include <utility> // std::swap
 #include "AlbersEqualArea.h"
 
 #if defined(_MSC_VER)

--- a/src/DST.cpp
+++ b/src/DST.cpp
@@ -8,6 +8,10 @@
  **********************************************************************/
 
 #include "DST.h"
+#include <cmath> // std::exp
+#include <complex> // std::complex
+#include <functional> //std::function
+#include <memory> // std::make_shared
 #include <vector>
 
 #include "kissfft.h"

--- a/src/Ellipsoid.cpp
+++ b/src/Ellipsoid.cpp
@@ -7,6 +7,8 @@
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
 
+#include <cmath>
+#include <limits> // std::numeric_limits
 #include "Ellipsoid.h"
 
 #if defined(_MSC_VER)

--- a/src/EllipticFunction.cpp
+++ b/src/EllipticFunction.cpp
@@ -7,6 +7,9 @@
  * https://geographiclib.sourceforge.io/
  **********************************************************************/
 
+#include <cmath>
+#include <limits> // std::numeric_limits
+#include <memory> // std::swap
 #include "EllipticFunction.h"
 
 #if defined(_MSC_VER)

--- a/src/Geodesic.cpp
+++ b/src/Geodesic.cpp
@@ -26,6 +26,11 @@
  * - s and c prefixes mean sin and cos
  **********************************************************************/
 
+#include <algorithm> // std::min
+#include <cmath>
+#include <limits> // std::numeric_limits
+#include <memory> // std::swap
+#include <__math/traits.h> // std::__math::isnan
 #include "Geodesic.h"
 #include "GeodesicLine.h"
 


### PR DESCRIPTION
As flagged by `clang-tidy`:

http://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html

Made it through 5 headers, I'll continue on another CRAN update in the future :)